### PR TITLE
version updated because of composer update errors.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,21 +7,21 @@
         "php": ">=8.1",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "league/oauth2-server": "^8.3",
-        "league/oauth2-server-bundle": "^0.4.0",
-        "symfony/asset": "6.1.*",
-        "symfony/console": "6.1.*",
-        "symfony/dotenv": "6.1.*",
+        "league/oauth2-server": "^8.5.1",
+        "league/oauth2-server-bundle": "^v0.5.0",
+        "symfony/asset": "6.2.*",
+        "symfony/console": "6.2.*",
+        "symfony/dotenv": "6.2.*",
         "symfony/flex": "^2",
-        "symfony/framework-bundle": "6.1.*",
-        "symfony/lock": "6.1.*",
+        "symfony/framework-bundle": "6.2.*",
+        "symfony/lock": "6.2.*",
         "symfony/maker-bundle": "^1.45",
-        "symfony/rate-limiter": "6.1.*",
-        "symfony/runtime": "6.1.*",
-        "symfony/templating": "6.1.*",
-        "symfony/twig-bundle": "6.1.*",
-        "symfony/uid": "6.1.*",
-        "symfony/yaml": "6.1.*",
+        "symfony/rate-limiter": "6.2.*",
+        "symfony/runtime": "6.2.*",
+        "symfony/templating": "6.2.*",
+        "symfony/twig-bundle": "6.2.*",
+        "symfony/uid": "6.2.*",
+        "symfony/yaml": "6.2.*",
         "ext-openssl": "*"
     },
     "config": {
@@ -73,11 +73,11 @@
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "6.1.*"
+            "require": "6.2.*"
         }
     },
     "require-dev": {
-        "symfony/stopwatch": "6.1.*",
-        "symfony/web-profiler-bundle": "6.1.*"
+        "symfony/stopwatch": "6.2.*",
+        "symfony/web-profiler-bundle": "6.2.*"
     }
 }


### PR DESCRIPTION
---

In NotSupported.php line 31:
!!
!!    Context: Using short namespace alias "LeagueOAuth2ServerBundle" by calling
!!    Doctrine\ORM\Configuration::addEntityNamespace
!!    Problem: Feature was deprecated in doctrine/persistence 2.x and is not supp
!!    orted by installed doctrine/persistence:3.x
!!    Solution: See the doctrine/deprecations logs for new alternative approaches
!!    .